### PR TITLE
修复gitlab关联权限设置和图片加载失败问题

### DIFF
--- a/services/codecc/codecc-config.md
+++ b/services/codecc/codecc-config.md
@@ -6,7 +6,7 @@
 
 ![同步执行方式配置](../../.gitbook/assets/image-codecc-sync-config.png)
 
-![同步执行的任务](../../.gitbook/assets/image-codecc-asynchronize)
+![同步执行的任务](../../.gitbook/assets/image-codecc-asynchronize.png)
 
 **异步执行方式：**
 

--- a/services/codecc/codecc-usage.md
+++ b/services/codecc/codecc-usage.md
@@ -26,7 +26,7 @@
 
 1. 使用accesstoken来关联
 2. 创建accesstoken的所有者须是目标仓库的maintainer角色
-3. accesstoken至少需要read\_api的权限
+3. accesstoken至少需要api的权限
 4. 源代码地址是http/https协议的
 
 accesstoken 使用「凭证管理」来进行注册，如果在「凭证管理」已经注册accesstoken，关联代码库时，可直接选中对应的accesstoken


### PR DESCRIPTION
fix:关联gitlab(14.1.3)的accesstoken至少需要api权限
fix:修复代码检查配置中同步执行的任务图片加载失败问题